### PR TITLE
Download official planner release

### DIFF
--- a/Makefile.tarball
+++ b/Makefile.tarball
@@ -1,15 +1,11 @@
 all: lama_planner
 
-TARBALL = build/ipc-2018-seq-sat.zip
-TARBALL_URL = 'https://bitbucket.org/ipc2018-classical/explicit-baseline-planners/get/ipc-2018-seq-sat.zip'
-SOURCE_DIR = build/LAMA
-UNPACK_CMD = unzip -d ../$(SOURCE_DIR)/
-ZIPFILE = build/ipc-2018-seq-sat.zip
-UNZIP_DIR = "$(SOURCE_DIR)/ipc2018-classical-explicit-baseline-planners-b7b739ba6ccd"
-include $(shell rospack find mk)/download_unpack_build.mk
+TARBALL=fast-downward-19.06.tar.gz
+TARBALL_URL=http://www.fast-downward.org/Releases/19.06?action=AttachFile&do=get&target=fast-downward-19.06.tar.gz
 
-lama_planner: $(SOURCE_DIR)/unpacked
-	rm -f $(ZIPFILE)
-	if [ -d $(UNZIP_DIR)/ ]; then mv $(UNZIP_DIR)/* $(SOURCE_DIR)/; fi
-	if [ -d $(UNZIP_DIR)/ ]; then rm -r $(UNZIP_DIR); fi
-	python $(SOURCE_DIR)/build.py
+lama_planner:
+	wget "$(TARBALL_URL)" -O fast-downward-19.06.tar.gz
+	tar sxvf $(TARBALL)
+	mv fast-downward-19.06 fast-downward
+	rm -f $(TARBALL)
+	python fast-downward/build.py

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ lama_planner
 
 The LAMA 2011 planner is built on the Fast Downward planning system and uses the PDDL format. It was used as baseline planner in the International Planning Competition (IPC) 2018. The planner was created by Silvia Richter (NICTA) and Matthias Westphal (Albert-Ludwigs-Universitat Freiburg).
 
-The source of the planner (as presented in IPC 2018) can be found [here](https://bitbucket.org/ipc2018-classical/explicit-baseline-planners/src/ipc-2018-seq-sat/)
+The official source of the planner (as presented in IPC 2018) can be found [on Bitbucket](https://bitbucket.org/ipc2018-classical/explicit-baseline-planners/src/ipc-2018-seq-sat/). The version that is downloaded by this package is the [official 19.06 release](http://www.fast-downward.org/Releases/19.06).
 
 This package downloads, unzips, and builds the files found there. The planner is then ready for use.
 


### PR DESCRIPTION
### Summary

This PR modifies the Makefile in the package so that an [official release of the Fast Downward planner](http://www.fast-downward.org/Releases/19.06) is downloaded.

### Necessity for the changes

The version that is currently downloaded from the planner's Bitbucket repository doesn't seem to build anymore (we first encountered this problem while setting up a Docker image for ROPOD's fleet management system, and I also encountered the problems on my machine, which is running a 64-bit Ubuntu 16.04).

### Tests to verify the changes

I have verified that the new version builds and works on my local machine, and we have also done that in the aforementioned Docker image.