### PR TITLE
Fix catkin build error due to moving fast-downward-19.06 to fast-downward

### DIFF
--- a/Makefile.tarball
+++ b/Makefile.tarball
@@ -6,6 +6,7 @@ TARBALL_URL=http://www.fast-downward.org/Releases/19.06?action=AttachFile&do=get
 lama_planner:
 	wget "$(TARBALL_URL)" -O fast-downward-19.06.tar.gz
 	tar sxvf $(TARBALL)
-	mv fast-downward-19.06 fast-downward
+	[ -d fast-downward ] && rm -rf fast-downward/*
+	mv fast-downward-19.06/* fast-downward
 	rm -f $(TARBALL)
 	python fast-downward/build.py


### PR DESCRIPTION
Catkin build error  - "mv error : directory fast-downward is not empty".
Cannot move fast-downward-19.06 to fast-downward directory since it is not empty. Hence, it is necessary to check if the directory fast-downward exists. If it does then it is emptied before moving the contents of fast-downward-19.06 to it.

## Changelog

* Makefile.tarball

## Checklist:

- [x] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)
