### PR TITLE
Fix make error in catkin build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 
-build/
+fast-downward/

--- a/Makefile.tarball
+++ b/Makefile.tarball
@@ -6,7 +6,7 @@ TARBALL_URL=http://www.fast-downward.org/Releases/19.06?action=AttachFile&do=get
 lama_planner:
 	wget "$(TARBALL_URL)" -O fast-downward-19.06.tar.gz
 	tar sxvf $(TARBALL)
-	[ -d fast-downward ] && rm -rf fast-downward || :
+	if [ -d fast-downward ]; then rm -rf fast-downward; fi
 	mv fast-downward-19.06 fast-downward
 	rm -f $(TARBALL)
 	python fast-downward/build.py

--- a/Makefile.tarball
+++ b/Makefile.tarball
@@ -6,7 +6,7 @@ TARBALL_URL=http://www.fast-downward.org/Releases/19.06?action=AttachFile&do=get
 lama_planner:
 	wget "$(TARBALL_URL)" -O fast-downward-19.06.tar.gz
 	tar sxvf $(TARBALL)
-	[ -d fast-downward ] && rm -rf fast-downward/*
-	mv fast-downward-19.06/* fast-downward
+	[ -d fast-downward ] && rm -rf fast-downward || :
+	mv fast-downward-19.06 fast-downward
 	rm -f $(TARBALL)
 	python fast-downward/build.py


### PR DESCRIPTION
Make error persists in catkin build due to [ -d fast-downward ] evaluating to false when initially cloning and building the repo. Changes have been made to remove fast-downward if it exists and if it doesnt [ -d fast-downward ] just returns true to prevent make error.

## Changelog
* Makefile.tarball
* .gitignore

## Related PRs
Related to #3 

## Checklist:
- [x] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)